### PR TITLE
[termux] minimal iiab login renaming.

### DIFF
--- a/iiab-termux
+++ b/iiab-termux
@@ -2,7 +2,7 @@
 set -euo pipefail
 
 # -----------------------------------------------------------------------------
-# GENERATED FILE: 2026-01-19T11:03:32-06:00 - do not edit directly.
+# GENERATED FILE: 2026-01-19T12:12:02-06:00 - do not edit directly.
 # Source modules: termux-setup/*.sh + manifest.sh
 # Rebuild: (cd termux-setup && bash build_bundle.sh)
 # -----------------------------------------------------------------------------
@@ -388,7 +388,7 @@ step_iiab_bootstrap_default() {
     ok "IIAB Debian bootstrap complete."
   else
     warn_red "IIAB Debian bootstrap incomplete (inner apt-get failed, rc=$rc)."
-    warn "You can retry later with: proot-distro login iiab"
+    warn "You can retry later with: iiab-termux --login"
   fi
 }
 
@@ -1081,7 +1081,7 @@ Usage:
     -> Termux baseline + IIAB Debian bootstrap (idempotent). No ADB prompts.
 
   iiab-termux --login
-    -> Login into IIAB Debian (proot-distro login iiab).
+    -> Login into IIAB Debian (iiab-termux --login).
 
   iiab-termux --with-adb
     -> Termux baseline + IIAB Debian bootstrap + ADB pair/connect if needed (skips if already connected).
@@ -1280,10 +1280,10 @@ final_advice() {
   case "$MODE" in
     baseline|with-adb|all)
       if iiab_exists; then
-        ok "Next: proot-distro login iiab"
+        ok "Next: iiab-termux --login"
       else
         warn "IIAB Debian not present. Run:"
-        warn "  proot-distro install --override-alias iiab debian"
+        warn "Preferred: iiab-termux --all"
       fi
       ;;
     *)
@@ -1343,7 +1343,7 @@ iiab_login() {
     fi
   fi
 
-  ok "Entering IIAB Debian: proot-distro login iiab"
+  ok "Entering IIAB Debian (via: iiab-termux --login)"
 
   # Preserve interactivity even if logging is enabled (avoid pipes/tee issues).
   if [[ -r /dev/tty ]]; then

--- a/termux-setup/30_mod_iiab-debian.sh
+++ b/termux-setup/30_mod_iiab-debian.sh
@@ -82,6 +82,6 @@ step_iiab_bootstrap_default() {
     ok "IIAB Debian bootstrap complete."
   else
     warn_red "IIAB Debian bootstrap incomplete (inner apt-get failed, rc=$rc)."
-    warn "You can retry later with: proot-distro login iiab"
+    warn "You can retry later with: iiab-termux --login"
   fi
 }

--- a/termux-setup/99_main.sh
+++ b/termux-setup/99_main.sh
@@ -37,7 +37,7 @@ Usage:
     -> Termux baseline + IIAB Debian bootstrap (idempotent). No ADB prompts.
 
   iiab-termux --login
-    -> Login into IIAB Debian (proot-distro login iiab).
+    -> Login into IIAB Debian (iiab-termux --login).
 
   iiab-termux --with-adb
     -> Termux baseline + IIAB Debian bootstrap + ADB pair/connect if needed (skips if already connected).
@@ -236,10 +236,10 @@ final_advice() {
   case "$MODE" in
     baseline|with-adb|all)
       if iiab_exists; then
-        ok "Next: proot-distro login iiab"
+        ok "Next: iiab-termux --login"
       else
         warn "IIAB Debian not present. Run:"
-        warn "  proot-distro install --override-alias iiab debian"
+        warn "Preferred: iiab-termux --all"
       fi
       ;;
     *)
@@ -299,7 +299,7 @@ iiab_login() {
     fi
   fi
 
-  ok "Entering IIAB Debian: proot-distro login iiab"
+  ok "Entering IIAB Debian (via: iiab-termux --login)"
 
   # Preserve interactivity even if logging is enabled (avoid pipes/tee issues).
   if [[ -r /dev/tty ]]; then


### PR DESCRIPTION
Applies changes for minimal changes to iiab-termux --login instead of proo-distro login iiab