### PR TITLE
Revise Termux setup instructions for Android versions

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ http://localhost:8085/maps
    ```
    curl iiab.io/termux.txt | bash
    ```
-   * In Android 12 and 13, make sure to opt in to the ADB Pair/Connect steps when prompted. You will be asked for 3 values: **Connect Port**, **Pair Port**, and **Pair Code**. Please check this (WIP) [video tutorial](https://ark.switnet.org/vid/termux_adb_pair_a16_hb.mp4) for a more interactive explanation. Once connected to ADB the `0_termux_setup.sh` script will handle the PPK workaround setup.
+   * In Android 12 and 13, make sure to opt in to the ADB Pair/Connect steps when prompted. You will be asked for 3 values: **Connect Port**, **Pair Port**, and **Pair Code**. Please check this (WIP) [video tutorial](https://ark.switnet.org/vid/termux_adb_pair_a16_hb.mp4) for a more interactive explanation. Once connected to ADB the `iiab-termux` script will handle the PPK workaround setup.
    
    * On Android 14 and later: Disable this restriction using Android Settings, in **Developer Options**:
 


### PR DESCRIPTION
Updated instructions for preparing the Termux environment on Android, including details on disabling the Phantom Process Killer (PPK) for Android 12 and 13, and clarifying steps for Android 14 and later.