### PR TITLE
[termux] adds mode to keep session active while on proot.

### DIFF
--- a/iiab-termux
+++ b/iiab-termux
@@ -2,7 +2,7 @@
 set -euo pipefail
 
 # -----------------------------------------------------------------------------
-# GENERATED FILE: 2026-01-20T22:17:22-06:00 - do not edit directly.
+# GENERATED FILE: 2026-01-21T09:41:35-06:00 - do not edit directly.
 # Source modules: termux-setup/*.sh + manifest.sh
 # Rebuild: (cd termux-setup && bash build_bundle.sh)
 # -----------------------------------------------------------------------------
@@ -549,6 +549,90 @@ ask_code_6digits() {
 }
 
 # ---- END 40_mod_termux_api.sh ----
+
+
+# ---- BEGIN 45_mod_power_mode.sh ----
+# shellcheck shell=bash
+# Module file (no shebang). Bundled by build_bundle.sh
+# Power-mode wrapper for proot login:
+# - Termux wakelock
+# - Persistent notification
+
+LOGIN_POWERMODE="${LOGIN_POWERMODE:-1}"        # 1=enable, 0=disable
+# Stable ID for the login session (derive from NOTIF_BASE_ID if available)
+LOGIN_NOTIF_ID="${LOGIN_NOTIF_ID:-$((NOTIF_BASE_ID + 75))}"
+LOGIN_NOTIF_ACTIVE=0
+POWER_MODE_ACQUIRED_WAKELOCK=0
+
+power_mode_login_enter() {
+  [[ "${LOGIN_POWERMODE:-1}" -eq 1 ]] || return 0
+  POWER_MODE_ACQUIRED_WAKELOCK=0
+  LOGIN_NOTIF_ACTIVE=0
+
+  # Wakelock. Avoid double-acquire.
+  local before_wl="${WAKELOCK_HELD:-0}"
+  if [[ "$before_wl" -ne 1 ]]; then
+    acquire_wakelock || true
+    [[ "${WAKELOCK_HELD:-0}" -eq 1 ]] && POWER_MODE_ACQUIRED_WAKELOCK=1
+  fi
+
+  # Persistent notification
+  if ! have termux-notification; then
+    warn "Power-mode: termux-notification not available. Install 'termux-api' + Termux:API app."
+    return 0
+  fi
+
+  # Remove any stale notif first (ignore errors)
+  if have termux-notification-remove; then
+    termux-notification-remove "$LOGIN_NOTIF_ID" >/dev/null 2>&1 || true
+  fi
+
+  local title="Internet-in-a-Box on Android"
+  local content="IIAB session active (proot). Keep the session running with the screen off."
+
+  if termux-notification \
+      --id "$LOGIN_NOTIF_ID" \
+      --ongoing \
+      --priority max \
+      --title "$title" \
+      --content "$content" \
+      >/dev/null 2>&1
+  then
+    LOGIN_NOTIF_ACTIVE=1
+    ok "Power-mode: enabled for this login session (persistent notification active)."
+  else
+    warn "Power-mode: failed to post notification (permission/app missing?)."
+    warn "Tip: install Termux:API app and grant notification permission to Termux."
+  fi
+
+  return 0
+}
+
+power_mode_login_exit() {
+  [[ "${LOGIN_POWERMODE:-1}" -eq 1 ]] || return 0
+  local did=0
+
+  # Remove persistent notification (best-effort)
+  if have termux-notification-remove; then
+    termux-notification-remove "$LOGIN_NOTIF_ID" >/dev/null 2>&1 || true
+  fi
+  if [[ "${LOGIN_NOTIF_ACTIVE:-0}" -eq 1 ]]; then
+    LOGIN_NOTIF_ACTIVE=0
+    did=1
+  fi
+
+  # Release wakelock (only if this script acquired it)
+  if [[ "${POWER_MODE_ACQUIRED_WAKELOCK:-0}" -eq 1 ]]; then
+    release_wakelock || true
+    POWER_MODE_ACQUIRED_WAKELOCK=0
+    did=1
+  fi
+
+  (( did )) && ok "Power-mode: released (notification removed, wakelock released)."
+  return 0
+}
+
+# ---- END 45_mod_power_mode.sh ----
 
 
 # ---- BEGIN 50_mod_adb.sh ----
@@ -1118,7 +1202,7 @@ Notes:
 EOF
 }
 
-trap 'cleanup_notif >/dev/null 2>&1 || true; release_wakelock >/dev/null 2>&1 || true' EXIT INT TERM
+trap 'power_mode_login_exit >/dev/null 2>&1 || true; cleanup_notif >/dev/null 2>&1 || true; release_wakelock >/dev/null 2>&1 || true' EXIT INT TERM
 
 # NOTE: Termux:API prompts live in 40_mod_termux_api.sh
 
@@ -1338,13 +1422,19 @@ iiab_login() {
   fi
 
   ok "Entering IIAB Debian (via: iiab-termux --login)"
-
+  power_mode_login_enter || true
   # Preserve interactivity even if logging is enabled (avoid pipes/tee issues).
+  local rc=0
   if [[ -r /dev/tty ]]; then
     proot-distro login iiab </dev/tty >&3 2>&4
+    rc=$?
   else
     proot-distro login iiab
+    rc=$?
   fi
+
+  power_mode_login_exit || true
+  return $rc
 }
 # -------------------------
 # Args

--- a/termux-setup/45_mod_power_mode.sh
+++ b/termux-setup/45_mod_power_mode.sh
@@ -1,0 +1,79 @@
+# shellcheck shell=bash
+# Module file (no shebang). Bundled by build_bundle.sh
+# Power-mode wrapper for proot login:
+# - Termux wakelock
+# - Persistent notification
+
+LOGIN_POWERMODE="${LOGIN_POWERMODE:-1}"        # 1=enable, 0=disable
+# Stable ID for the login session (derive from NOTIF_BASE_ID if available)
+LOGIN_NOTIF_ID="${LOGIN_NOTIF_ID:-$((NOTIF_BASE_ID + 75))}"
+LOGIN_NOTIF_ACTIVE=0
+POWER_MODE_ACQUIRED_WAKELOCK=0
+
+power_mode_login_enter() {
+  [[ "${LOGIN_POWERMODE:-1}" -eq 1 ]] || return 0
+  POWER_MODE_ACQUIRED_WAKELOCK=0
+  LOGIN_NOTIF_ACTIVE=0
+
+  # Wakelock. Avoid double-acquire.
+  local before_wl="${WAKELOCK_HELD:-0}"
+  if [[ "$before_wl" -ne 1 ]]; then
+    acquire_wakelock || true
+    [[ "${WAKELOCK_HELD:-0}" -eq 1 ]] && POWER_MODE_ACQUIRED_WAKELOCK=1
+  fi
+
+  # Persistent notification
+  if ! have termux-notification; then
+    warn "Power-mode: termux-notification not available. Install 'termux-api' + Termux:API app."
+    return 0
+  fi
+
+  # Remove any stale notif first (ignore errors)
+  if have termux-notification-remove; then
+    termux-notification-remove "$LOGIN_NOTIF_ID" >/dev/null 2>&1 || true
+  fi
+
+  local title="Internet-in-a-Box on Android"
+  local content="IIAB session active (proot). Keep the session running with the screen off."
+
+  if termux-notification \
+      --id "$LOGIN_NOTIF_ID" \
+      --ongoing \
+      --priority max \
+      --title "$title" \
+      --content "$content" \
+      >/dev/null 2>&1
+  then
+    LOGIN_NOTIF_ACTIVE=1
+    ok "Power-mode: enabled for this login session (persistent notification active)."
+  else
+    warn "Power-mode: failed to post notification (permission/app missing?)."
+    warn "Tip: install Termux:API app and grant notification permission to Termux."
+  fi
+
+  return 0
+}
+
+power_mode_login_exit() {
+  [[ "${LOGIN_POWERMODE:-1}" -eq 1 ]] || return 0
+  local did=0
+
+  # Remove persistent notification (best-effort)
+  if have termux-notification-remove; then
+    termux-notification-remove "$LOGIN_NOTIF_ID" >/dev/null 2>&1 || true
+  fi
+  if [[ "${LOGIN_NOTIF_ACTIVE:-0}" -eq 1 ]]; then
+    LOGIN_NOTIF_ACTIVE=0
+    did=1
+  fi
+
+  # Release wakelock (only if this script acquired it)
+  if [[ "${POWER_MODE_ACQUIRED_WAKELOCK:-0}" -eq 1 ]]; then
+    release_wakelock || true
+    POWER_MODE_ACQUIRED_WAKELOCK=0
+    did=1
+  fi
+
+  (( did )) && ok "Power-mode: released (notification removed, wakelock released)."
+  return 0
+}

--- a/termux-setup/99_main.sh
+++ b/termux-setup/99_main.sh
@@ -80,7 +80,7 @@ Notes:
 EOF
 }
 
-trap 'cleanup_notif >/dev/null 2>&1 || true; release_wakelock >/dev/null 2>&1 || true' EXIT INT TERM
+trap 'power_mode_login_exit >/dev/null 2>&1 || true; cleanup_notif >/dev/null 2>&1 || true; release_wakelock >/dev/null 2>&1 || true' EXIT INT TERM
 
 # NOTE: Termux:API prompts live in 40_mod_termux_api.sh
 
@@ -300,13 +300,19 @@ iiab_login() {
   fi
 
   ok "Entering IIAB Debian (via: iiab-termux --login)"
-
+  power_mode_login_enter || true
   # Preserve interactivity even if logging is enabled (avoid pipes/tee issues).
+  local rc=0
   if [[ -r /dev/tty ]]; then
     proot-distro login iiab </dev/tty >&3 2>&4
+    rc=$?
   else
     proot-distro login iiab
+    rc=$?
   fi
+
+  power_mode_login_exit || true
+  return $rc
 }
 # -------------------------
 # Args

--- a/termux-setup/manifest.sh
+++ b/termux-setup/manifest.sh
@@ -7,6 +7,7 @@ MODULES=(
   "20_mod_termux_base.sh"
   "30_mod_iiab-debian.sh"
   "40_mod_termux_api.sh"
+  "45_mod_power_mode.sh"
   "50_mod_adb.sh"
   "60_mod_ppk_checks.sh"
   "99_main.sh"


### PR DESCRIPTION
This mode allows to get a persistent notification keeping the app relevant along with termux wakelock allows run IIAB (proot) even with the screen off.

This provides a first good starting point in process resilience.