### PR TITLE
[README] simplify instructions on pdsm services

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,7 +95,7 @@ http://localhost:8085/maps
 
 ## Test your IIAB install
 
-IIAB [`pdsm` services](https://github.com/iiab/iiab/tree/master/roles/proot_se) start automatically after installation. To check that your IIAB Apps are working (using a browser on your Android device) by visiting these URLs:
+IIAB [`pdsm` services](https://github.com/iiab/iiab/tree/master/roles/proot_services) start automatically after installation. To check that your IIAB Apps are working (using a browser on your Android device) by visiting these URLs:
 
 | App                    | URL                                                            |
 |------------------------|----------------------------------------------------------------|


### PR DESCRIPTION
After several fixes, we can confirm that all services are working correctly on install, so even custom local_vars should match the environment they install.
- https://github.com/iiab/iiab/pull/4245
- https://github.com/iiab/iiab/pull/4246
- https://github.com/iiab/iiab/pull/4248

So there is no need to manually start services, and on custom installations (with custom local_vars.yml) not recommend:
```
pdsm start-all
```

As only the (cherry-picked) installed services should de started.